### PR TITLE
Specs passing using ruby 1.9.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,5 @@ group :development do
   gem "webmock"
   gem "vcr"
   gem "capybara"
+  gem "ruby-debug19"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     addressable (2.2.5)
+    archive-tar-minitar (0.5.2)
     capybara (0.4.1.2)
       celerity (>= 0.7.9)
       culerity (>= 0.2.4)
@@ -14,6 +15,7 @@ GEM
     celerity (0.8.9)
     childprocess (0.1.8)
       ffi (~> 1.0.6)
+    columnize (0.3.4)
     crack (0.1.8)
     culerity (0.2.15)
     diff-lcs (1.1.2)
@@ -29,6 +31,8 @@ GEM
       git (>= 1.2.5)
       rake
     json_pure (1.5.1)
+    linecache19 (0.5.12)
+      ruby_core_source (>= 0.1.4)
     mime-types (1.16)
     nokogiri (1.4.4)
     rack (1.2.2)
@@ -44,6 +48,16 @@ GEM
     rspec-expectations (2.3.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.3.0)
+    ruby-debug-base19 (0.11.25)
+      columnize (>= 0.3.1)
+      linecache19 (>= 0.5.11)
+      ruby_core_source (>= 0.1.4)
+    ruby-debug19 (0.11.6)
+      columnize (>= 0.3.1)
+      linecache19 (>= 0.5.11)
+      ruby-debug-base19 (>= 0.11.19)
+    ruby_core_source (0.1.5)
+      archive-tar-minitar (>= 0.5.2)
     rubyzip (0.9.4)
     selenium-webdriver (0.1.4)
       childprocess (>= 0.1.7)
@@ -71,6 +85,7 @@ DEPENDENCIES
   jeweler (~> 1.5.2)
   rcov
   rspec (~> 2.3.0)
+  ruby-debug19
   vcr
   webmock
   yard (~> 0.6.0)

--- a/spec/direct_response_parameters_spec.rb
+++ b/spec/direct_response_parameters_spec.rb
@@ -3,13 +3,13 @@ require 'spec_helper'
 module Chargify2
   describe Direct::ResponseParameters do
     let(:client) { Client.new(valid_client_credentials) }
-    
+
     it "raises an argument error if it could not get an api_id and secret from the passed client" do
       lambda {
         Direct::SecureParameters.new({}, OpenCascade.new)
       }.should raise_error(ArgumentError)
     end
-    
+
     describe "#verified?" do
       before(:each) do
         @api_id = valid_client_credentials[:api_id]
@@ -18,7 +18,7 @@ module Chargify2
         @status_code = '200'
         @result_code = '2000'
         @call_id = 'blah'
-        
+
         # Used the generator here: http://hash.online-convert.com/sha1-generator
         # ... with message: "1c016050-498a-012e-91b1-005056a216ab13032453261c016050-498a-012e-91b1-005056a216ab2002000blah"
         # ... and secret: "p5lxQ804MYtwZecFWNOT"
@@ -36,10 +36,10 @@ module Chargify2
           'call_id' => @call_id,
           'signature' => @signature
         }, client)
-        
+
         rp.verified?.should be_true
       end
-      
+
       it "returns false when the calculated signature of the result params is different from the received signature" do
         rp = Direct::ResponseParameters.new({
           'api_id' => @api_id,
@@ -50,10 +50,10 @@ module Chargify2
           'call_id' => @call_id,
           'signature' => 'foo'
         }, client)
-        
+
         rp.verified?.should be_false
       end
-      
+
       it "returns false when the calculated signature is correct but the api_id does not match the client's" do
         other_client_credentials = valid_client_credentials.merge(:api_id => '1')
         other_client = Client.new(other_client_credentials)
@@ -67,7 +67,7 @@ module Chargify2
           'call_id' => @call_id,
           'signature' => @signature
         }, other_client)
-        
+
         rp.verified?.should be_false
       end
     end

--- a/spec/direct_secure_parameters_spec.rb
+++ b/spec/direct_secure_parameters_spec.rb
@@ -3,30 +3,30 @@ require 'spec_helper'
 module Chargify2
   describe Direct::SecureParameters do
     let(:client) { Client.new(valid_client_credentials) }
-    
+
     it "raises an argument error if data is provided but it is not in hash format" do
       lambda {
         Direct::SecureParameters.new({'data' => 'string'}, client)
       }.should raise_error(ArgumentError)
     end
-    
+
     it "raises an argument error if it could not get an api_id and secret from the passed client" do
       lambda {
         Direct::SecureParameters.new({}, OpenCascade.new)
       }.should raise_error(ArgumentError)
     end
-    
+
     describe "#timestamp?" do
       it "returns true when a timestamp is provided via a string hash key" do
         sp = Direct::SecureParameters.new({'timestamp' => '1234'}, client)
         sp.timestamp?.should be_true
       end
-      
+
       it "returns true when a timestamp is provided via a symbol hash key" do
         sp = Direct::SecureParameters.new({:timestamp => '1234'}, client)
         sp.timestamp?.should be_true
       end
-      
+
       it "returns false when a timestamp key/value is not provided" do
         sp = Direct::SecureParameters.new({}, client)
         sp.timestamp?.should be_false
@@ -48,12 +48,12 @@ module Chargify2
         sp = Direct::SecureParameters.new({'nonce' => '1234'}, client)
         sp.nonce?.should be_true
       end
-      
+
       it "returns true when a nonce is provided via a symbol hash key" do
         sp = Direct::SecureParameters.new({:nonce => '1234'}, client)
         sp.nonce?.should be_true
       end
-      
+
       it "returns false when a nonce key/value is not provided" do
         sp = Direct::SecureParameters.new({}, client)
         sp.nonce?.should be_false
@@ -75,12 +75,12 @@ module Chargify2
         sp = Direct::SecureParameters.new({'data' => {'foo' => 'bar'}}, client)
         sp.data?.should be_true
       end
-      
+
       it "returns true when data is provided via a symbol hash key" do
         sp = Direct::SecureParameters.new({:data => {'foo' => 'bar'}}, client)
         sp.data?.should be_true
       end
-      
+
       it "returns false when a data key/value is not provided" do
         sp = Direct::SecureParameters.new({}, client)
         sp.data?.should be_false
@@ -96,24 +96,24 @@ module Chargify2
         sp.data?.should be_false
       end
     end
-    
+
     describe "#encoded_data" do
       it "turns the data hash in to query string format" do
         sp = Direct::SecureParameters.new({'data' => {'one' => 'two', 'three' => 'four'}}, client)
         sp.encoded_data.should == "one=two&three=four"
       end
-      
+
       it "turns a nested data hash in to nested query string format" do
         sp = Direct::SecureParameters.new({'data' => {'one' => {'two' => {'three' => 'four'}}, 'foo' => 'bar'}}, client)
         sp.encoded_data.should == "foo=bar&one[two][three]=four"
       end
-      
+
       it "performs percent encoding on unsafe characters" do
         sp = Direct::SecureParameters.new({'data' => {'redirect_uri' => 'http://www.example.com', 'sentence' => 'Michael was here!'}}, client)
         sp.encoded_data.should == "redirect_uri=http%3A%2F%2Fwww.example.com&sentence=Michael%20was%20here%21"
       end
     end
-    
+
     describe "#to_form_inputs" do
       context "with no timestamp, nonce, nor data" do
         it "outputs 2 hidden form inputs - one for the api_id and one for the signature" do
@@ -125,7 +125,7 @@ module Chargify2
           form.should have_selector("input[type='hidden'][name='secure[signature]'][value='#{sp.signature}']", :count => 1)
         end
       end
-      
+
       context "with a timestamp" do
         it "outputs 3 hidden form inputs - one each for the api_id, timestamp, and signature" do
           sp = Direct::SecureParameters.new({'timestamp' => '1234'}, client)
@@ -183,7 +183,7 @@ module Chargify2
         nonce = '5678'
         data = {'one' => 'two', 'three' => {'four' => "http://www.example.com"}}
         sp = Direct::SecureParameters.new({'timestamp' => timestamp, 'nonce' => nonce, 'data' => data}, client)
-        
+
         # Used the generator here: http://hash.online-convert.com/sha1-generator
         # ... with message: "1c016050-498a-012e-91b1-005056a216ab12345678one=two&three[four]=http%3A%2F%2Fwww.example.com"
         # ... and secret: "p5lxQ804MYtwZecFWNOT"


### PR DESCRIPTION
Some of the specs were failing with ruby 1.9.2 due to changes in Hash#to_s between ruby 1.8 and 1.9. 1.8 was returning an empty string where 1.9 is returning "{}". This meant that checking that the length of Hash_#to_s was returning 2 instead of 0 as expected. I've updated the code with a new check in place that will still allow those values to be a string, hash or integer, but does the proper checks to see if they're empty.
