### PR TITLE
Fix Digest deprecation warning on ruby 2.1

### DIFF
--- a/lib/chargify2/direct.rb
+++ b/lib/chargify2/direct.rb
@@ -16,7 +16,7 @@ module Chargify2
     end
 
     def self.signature(message, secret)
-      OpenSSL::HMAC.hexdigest(OpenSSL::Digest::Digest.new('sha1'), secret, message)
+      OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), secret, message)
     end
 
     private


### PR DESCRIPTION
I'm not sure what effect this will have on older ruby versions.  Let's see what the tests say.
