### PR TITLE
Remove date from gemspec

### DIFF
--- a/chargify2.gemspec
+++ b/chargify2.gemspec
@@ -5,7 +5,6 @@ Gem::Specification.new do |s|
 
   s.name    = 'chargify2'
   s.version = '0.2.8'
-  s.date    = '2014-04-27'
   s.summary = %q{Chargify API V2 Ruby Wrapper}
   s.description = ''
   s.authors = ["Michael Klett", "Shay Frendt", "Jeremy W. Rowe"]


### PR DESCRIPTION
Rubygems will default it to the current UTC date.

See: http://rubygems.rubyforge.org/rubygems-update/Gem/Specification.html#method-i-date

One less thing to remember when pushing a new release. :smile: 
