### PR TITLE
Fix OpenSSL deprecation warning on Digest::Digest

### DIFF
--- a/lib/chargify2/direct.rb
+++ b/lib/chargify2/direct.rb
@@ -16,7 +16,7 @@ module Chargify2
     end
 
     def self.signature(message, secret)
-      OpenSSL::HMAC.hexdigest(OpenSSL::Digest::Digest.new('sha1'), secret, message)
+      OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), secret, message)
     end
 
     private


### PR DESCRIPTION
This silences the following deprecation warning: "Digest::Digest is deprecated; use Digest".

`OpenSSL::Digest::Digest` has been deprecated in favor of `OpenSSL::Digest` since ruby 1.8.7 [(source)](https://github.com/ruby/ruby/blob/ruby_1_8_7/ext/openssl/lib/openssl/digest.rb#L51)