### PR TITLE
Remove script tags from text fields.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
       hashie
       httparty (= 0.11.0)
       rack
+      sanitize (= 4.2.0)
 
 GEM
   remote: http://rubygems.org/
@@ -22,6 +23,7 @@ GEM
       ffi (~> 1.0, >= 1.0.6)
     coderay (1.0.9)
     crack (0.3.1)
+    crass (1.0.2)
     diff-lcs (1.1.3)
     ffi (1.1.5)
     hashery (2.1.1)
@@ -36,6 +38,8 @@ GEM
     multi_json (1.3.6)
     multi_xml (0.5.5)
     nokogiri (1.5.5)
+    nokogumbo (1.4.9)
+      nokogiri
     pry (0.9.12.1)
       coderay (~> 1.0.5)
       method_source (~> 0.8)
@@ -53,6 +57,10 @@ GEM
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.11.2)
     rubyzip (0.9.9)
+    sanitize (4.2.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.4.4)
+      nokogumbo (~> 1.4.1)
     selenium-webdriver (2.25.0)
       childprocess (>= 0.2.5)
       libwebsocket (~> 0.1.3)

--- a/chargify2.gemspec
+++ b/chargify2.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('hashery', '~> 2.1.0')
   s.add_runtime_dependency('hashie', '>= 0')
   s.add_runtime_dependency('httparty', '0.11.0')
+  s.add_runtime_dependency('sanitize', '4.2.0')
 
   # Development Dependencies
   s.add_development_dependency('rake', '~> 0.9.2.2')

--- a/lib/chargify2.rb
+++ b/lib/chargify2.rb
@@ -2,6 +2,7 @@ require 'httparty'
 require 'rack'
 require 'hashie'
 require 'hashery'
+require 'sanitize'
 
 require 'chargify2/utils'
 require 'chargify2/direct'

--- a/lib/chargify2/resource.rb
+++ b/lib/chargify2/resource.rb
@@ -34,7 +34,7 @@ module Chargify2
       response_hash = response.send(representation.to_s.downcase.split('::').last) || {}
 
       self.create_response(
-        representation.new(response_hash),
+        representation.new(sanitized(response_hash)),
         response.meta
       )
     end
@@ -51,7 +51,7 @@ module Chargify2
       response_hash = response.send(plural_name) || {}
 
       self.create_response(
-        response_hash.map{|resource| representation.new(resource)},
+        sanitized(response_hash).map{|resource| representation.new(resource)},
         response.meta
       )
     end
@@ -68,7 +68,7 @@ module Chargify2
       response_hash = response.send(singular_name) || {}
 
       self.create_response(
-        representation.new(response_hash),
+        representation.new(sanitized(response_hash)),
         response.meta
       )
     end
@@ -85,7 +85,7 @@ module Chargify2
       response_hash = response.send(singular_name) || {}
 
       self.create_response(
-        representation.new(response_hash),
+        representation.new(sanitized(response_hash)),
         response.meta
       )
     end
@@ -102,7 +102,7 @@ module Chargify2
       response_hash = response.send(singular_name) || {}
 
       self.create_response(
-        representation.new(response_hash),
+        representation.new(sanitized(response_hash)),
         response.meta
       )
     end
@@ -141,6 +141,10 @@ module Chargify2
         options.merge!(:basic_auth => @auth)
       end
       options
+    end
+
+    def self.sanitized(response_hash)
+      Chargify2::Utils.sanitize_response(response_hash)
     end
   end
 end

--- a/lib/chargify2/utils.rb
+++ b/lib/chargify2/utils.rb
@@ -28,5 +28,23 @@ module Chargify2
       word.downcase!
       word
     end
+
+    def self.sanitize_response(response_hash)
+      return response_hash unless response_hash.is_a? Array
+      response_hash.map { |rh| self.sanitize(rh) }
+    end
+
+    private
+
+    def self.sanitize(hash)
+      hash.each do |key, value|
+        hash[key] = case value
+          when String then Sanitize.fragment(value, Sanitize::Config::RELAXED)
+          when Hash   then self.sanitize(value)
+          else value
+        end
+      end
+      hash
+    end
   end
 end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Chargify2::Utils do
+
+  describe "#sanitize_response" do
+    let(:sanitized_response) do
+      described_class.sanitize_response([{ kylo:  "<script>alert(1)</script>", ren:   { ben: "<script>alert('solo')</script>"    } },
+                                         { darth: "<script>alert(2)</script>", vader: { ani: "<script>alert('sky guy')</script>" } }])
+    end
+
+    it "sanitizes the response" do
+      expect(sanitized_response.first[:kylo]).to eql("alert(1)")
+    end
+
+    it "deeply sanitizes the response" do
+      expect(sanitized_response.first[:ren][:ben]).to eql("alert('solo')")
+    end
+
+    it "sanitizes multiple items" do
+      expect(sanitized_response.last[:darth]).to eql("alert(2)")
+    end
+  end
+end


### PR DESCRIPTION
This sanitizes the api response from Chargify, preventing XSS attacks.