### PR TITLE
Add reason codes

### DIFF
--- a/lib/chargify2.rb
+++ b/lib/chargify2.rb
@@ -29,6 +29,8 @@ require 'chargify2/representations/subscriptions_component'
 require 'chargify2/representations/allocation'
 require 'chargify2/representations/renewal_preview'
 require 'chargify2/representations/metadatum'
+require 'chargify2/representations/reason_codes'
+require 'chargify2/representations/reason_code'
 
 # resources
 require 'chargify2/resources/call_resource'
@@ -42,3 +44,4 @@ require 'chargify2/resources/allocation_resource'
 require 'chargify2/resources/allocation_preview_resource'
 require 'chargify2/resources/renewal_preview_resource'
 require 'chargify2/resources/metadatum_resource'
+require 'chargify2/resources/reason_code_resource'

--- a/lib/chargify2/client.rb
+++ b/lib/chargify2/client.rb
@@ -73,5 +73,9 @@ module Chargify2
     def metadata
       Chargify2::MetadatumResource.new(self)
     end
+
+    def reason_codes
+      Chargify2::ReasonCodeResource.new(self)
+    end
   end
 end

--- a/lib/chargify2/representations/reason_code.rb
+++ b/lib/chargify2/representations/reason_code.rb
@@ -1,0 +1,3 @@
+module Chargify2
+  ReasonCode = Class.new(Representation)
+end

--- a/lib/chargify2/representations/reason_codes.rb
+++ b/lib/chargify2/representations/reason_codes.rb
@@ -1,0 +1,9 @@
+module Chargify2
+  class ReasonCodes < Representation
+    def reason_codes
+      @reason_codes ||= begin
+        (self[:reason_codes] || {}).map{|rc| ReasonCode.new(rc) }
+      end
+    end
+  end
+end

--- a/lib/chargify2/resources/reason_code_resource.rb
+++ b/lib/chargify2/resources/reason_code_resource.rb
@@ -1,0 +1,13 @@
+module Chargify2
+  class ReasonCodeResource < Resource
+
+    def self.path
+      'reason_codes'
+    end
+
+    def self.representation
+      ReasonCode
+    end
+
+  end
+end

--- a/lib/chargify2/resources/reason_code_resource.rb
+++ b/lib/chargify2/resources/reason_code_resource.rb
@@ -6,7 +6,7 @@ module Chargify2
     end
 
     def self.representation
-      ReasonCode
+      ReasonCodes
     end
 
   end

--- a/spec/representations/reason_codes_spec.rb
+++ b/spec/representations/reason_codes_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe Chargify2::ReasonCodes do
+  let(:reason_codes) { described_class.new(successful_response) }
+
+  it "is a Chargify2::ReasonCode object" do
+    expect(reason_codes).to be_a(Chargify2::ReasonCodes)
+  end
+
+  it "it parses the response correctly" do
+    expect(reason_codes.reason_codes[0].code).to eql "CARO"
+  end
+
+  it "has access to the product family" do
+    expect(reason_codes.reason_codes[0].description).to eql "Too Expensive"
+  end
+
+  private
+
+  def successful_response
+    {"reason_codes" => [{"code" => "CARO","description"=>"Too Expensive","position"=>1}]}
+  end
+end

--- a/spec/resources/reason_code_resource_spec.rb
+++ b/spec/resources/reason_code_resource_spec.rb
@@ -7,7 +7,7 @@ module Chargify2
     end
 
     it "represents with the ReasonCode class" do
-      described_class.representation.should == ReasonCode
+      described_class.representation.should == ReasonCodes
     end
 
     context 'with an instance configured with a client' do

--- a/spec/resources/reason_code_resource_spec.rb
+++ b/spec/resources/reason_code_resource_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+module Chargify2
+  describe ReasonCodeResource do
+    it "should have a path of 'reason_codes'" do
+      described_class.path.should == 'reason_codes'
+    end
+
+    it "represents with the ReasonCode class" do
+      described_class.representation.should == ReasonCode
+    end
+
+    context 'with an instance configured with a client' do
+      let(:client) { Client.new(valid_client_credentials) }
+      let!(:reason_code_resource) { ReasonCodeResource.new(client) }
+
+
+      describe '.list' do
+        it 'ignores the instance configuration and uses class defaults' do
+          WebMock.stub_request(:get, 'https://api.chargify.com/api/v2/reason_codes')
+          ReasonCodeResource.list
+          a_request(:get, 'https://api.chargify.com/api/v2/reason_codes').should have_been_made.once
+        end
+      end
+
+      describe '#list' do
+        it "performs a GET request to 'https://<api_login>:<api_password>@api.chargify.com/api/v2/reason_codes' (with authentication) when called" do
+          WebMock.stub_request(:get, client_authenticated_uri(client, '/reason_codes'))
+          reason_code_resource.list
+          a_request(:get, client_authenticated_uri(client, '/reason_codes')).should have_been_made.once
+        end
+
+        it "returns an array of ReasonCode representations" do
+          WebMock.stub_request(:get, client_authenticated_uri(client, '/reason_codes'))
+          reason_code_resource.list.resource.all?{|rc| rc.is_a?(ReasonCode)}
+        end
+      end
+    end
+
+    def client_authenticated_uri(client, path)
+      uri = URI(client.base_uri)
+      uri.user = client.api_id
+      uri.password = client.api_password
+
+      uri.to_s + path
+    end
+  end
+end


### PR DESCRIPTION
To support the churn codes feature effort, add reason code listing capability so that it can be displayed in the portal GUI.