### PR TITLE
[bugfix] Singularize ReasonCode representation name

### DIFF
--- a/lib/chargify2/resources/reason_code_resource.rb
+++ b/lib/chargify2/resources/reason_code_resource.rb
@@ -6,7 +6,7 @@ module Chargify2
     end
 
     def self.representation
-      ReasonCodes
+      ReasonCode
     end
 
   end


### PR DESCRIPTION
## Description
Adjusts representation name to be singular which was raising an error when `resource.rb` was trying to call `plural_name` on it.